### PR TITLE
Feature: transparency updates

### DIFF
--- a/src/codegen/template.rs
+++ b/src/codegen/template.rs
@@ -4,7 +4,8 @@ use crate::codegen::{
 };
 use askama::{Error, Template};
 use ruint::aliases::U256;
-use std::fmt;
+use std::fmt::{self, Display};
+
 
 #[derive(Template)]
 #[template(path = "Halo2VerifyingKey.sol")]
@@ -61,7 +62,7 @@ impl Halo2Verifier {
 }
 
 mod filters {
-    use std::fmt::LowerHex;
+    use std::fmt::{LowerHex, Display};
 
     pub fn hex(value: impl LowerHex) -> ::askama::Result<String> {
         let value = format!("{value:x}");
@@ -80,4 +81,22 @@ mod filters {
             Ok(string)
         }
     }
+
+    pub fn left_pad(value: impl Display, width: usize) -> ::askama::Result<String> {
+        let string = format!("{:>width$}", value, width = width);
+        Ok(string)
+    }
+}
+
+pub fn index_coord(value: impl Display, index: &usize, coord: impl Display) -> String {
+    format!(
+        "{}_{}_{}",
+        value.to_string().to_uppercase(),
+        index,
+        coord.to_string().to_uppercase()
+    )
+}
+
+pub fn vk_var_name(value: impl Display) -> String {
+    format!("VK_{}_VAL", value.to_string().to_uppercase())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,11 @@ mod transcript;
 mod test;
 
 pub use codegen::{AccumulatorEncoding, BatchOpenScheme, SolidityGenerator};
-pub use evm::{encode_calldata, FN_SIG_VERIFY_PROOF, FN_SIG_VERIFY_PROOF_WITH_VK_ADDRESS};
+pub use evm::{
+    encode_calldata, get_key_calldata, FN_SIG_GET_VERIFYING_KEY,
+    FN_SIG_GET_VERIFYING_KEY_WITH_VK_ADDRESS, FN_SIG_VERIFY_PROOF,
+    FN_SIG_VERIFY_PROOF_WITH_VK_ADDRESS,
+};
 pub use transcript::Keccak256Transcript;
 
 #[cfg(feature = "evm")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ mod test;
 
 pub use codegen::{AccumulatorEncoding, BatchOpenScheme, SolidityGenerator};
 pub use evm::{
-    encode_calldata, get_key_calldata, FN_SIG_GET_VERIFYING_KEY,
+    encode_calldata, get_vkey_calldata, FN_SIG_GET_VERIFYING_KEY,
     FN_SIG_GET_VERIFYING_KEY_WITH_VK_ADDRESS, FN_SIG_VERIFY_PROOF,
     FN_SIG_VERIFY_PROOF_WITH_VK_ADDRESS,
 };

--- a/templates/Halo2Verifier.sol
+++ b/templates/Halo2Verifier.sol
@@ -84,7 +84,7 @@ contract Halo2Verifier {
     uint256 internal constant {{ self::index_coord("permutation_comms", loop.index0, "y")|left_pad(24) }} = {{ y|hex_padded(64) }};
     {%- endfor %}
 
-    function getVerifyingKey() public view returns (uint256[{{ vk_len / 0x20 }}] memory) {
+    function getVerifyingKey() public view returns (uint256[{{ vk_len / 32 }}] memory) {
         return [
     {%- for (name, chunk) in vk_.constants %}
             {{ self::vk_var_name(name)|left_pad(24) }},
@@ -102,7 +102,7 @@ contract Halo2Verifier {
 
     {%- else %}
 
-    function getVerifyingKey(address vk) public view returns (uint256[{{ vk_len / 0x20 }}] memory) {
+    function getVerifyingKey(address vk) public view returns (uint256[{{ vk_len / 32 }}] memory) {
         assembly {
             extcodecopy(vk, VK_MPTR, 0x00, {{ vk_len|hex() }})
             return (VK_MPTR, {{ vk_len|hex() }})

--- a/templates/Halo2Verifier.sol
+++ b/templates/Halo2Verifier.sol
@@ -69,6 +69,47 @@ contract Halo2Verifier {
     uint256 internal constant   PAIRING_RHS_X_MPTR = {{ theta_mptr + 24 }};
     uint256 internal constant   PAIRING_RHS_Y_MPTR = {{ theta_mptr + 25 }};
 
+    {%- if let Some(vk_) = vk %}
+
+    // verifying key parameters
+    {%- for (name, chunk) in vk_.constants %}
+    uint256 internal constant {{ self::vk_var_name(name)|left_pad(24) }} = {{ chunk|hex_padded(64) }};
+    {%- endfor %}
+    {%- for (x, y) in vk_.fixed_comms %}
+    uint256 internal constant {{ self::index_coord("fixed_comms", loop.index0, "x")|left_pad(24) }} = {{ x|hex_padded(64) }};
+    uint256 internal constant {{ self::index_coord("fixed_comms", loop.index0, "y")|left_pad(24) }} = {{ y|hex_padded(64) }};
+    {%- endfor %}
+    {%- for (x, y) in vk_.permutation_comms %}
+    uint256 internal constant {{ self::index_coord("permutation_comms", loop.index0, "x")|left_pad(24) }} = {{ x|hex_padded(64) }};
+    uint256 internal constant {{ self::index_coord("permutation_comms", loop.index0, "y")|left_pad(24) }} = {{ y|hex_padded(64) }};
+    {%- endfor %}
+
+    function getVerifyingKey() public view returns (uint256[{{ vk_len / 0x20 }}] memory) {
+        return [
+    {%- for (name, chunk) in vk_.constants %}
+            {{ self::vk_var_name(name)|left_pad(24) }},
+    {%- endfor %}
+    {%- for (x, y) in vk_.fixed_comms %}
+            {{ self::index_coord("fixed_comms", loop.index0, "x")|left_pad(24) }},
+            {{ self::index_coord("fixed_comms", loop.index0, "y")|left_pad(24) }},
+    {%- endfor %}
+    {%- for (x, y) in vk_.permutation_comms %}
+            {{ self::index_coord("permutation_comms", loop.index0, "x")|left_pad(24) }},
+            {{ self::index_coord("permutation_comms", loop.index0, "y")|left_pad(24) }}{%- if loop.index < vk_.permutation_comms.len() %},{%- endif %}
+    {%- endfor %}
+        ];
+    }
+
+    {%- else %}
+
+    function getVerifyingKey(address vk) public view returns (uint256[{{ vk_len / 0x20 }}] memory) {
+        assembly {
+            extcodecopy(vk, VK_MPTR, 0x00, {{ vk_len|hex() }})
+            return (VK_MPTR, {{ vk_len|hex() }})
+        }
+    }
+    {%- endif %}
+
     function verifyProof(
         {%- match vk %}
         {%- when Some with (vk) %}
@@ -227,17 +268,17 @@ contract Halo2Verifier {
                 {%- when Some with (vk) %}
                 // Load vk into memory
                 {%- for (name, chunk) in vk.constants %}
-                mstore({{ vk_mptr + loop.index0 }}, {{ chunk|hex_padded(64) }}) // {{ name }}
+                mstore({{ vk_mptr + loop.index0 }}, {{ self::vk_var_name(name)|left_pad(24) }}) // {{ name }}
                 {%- endfor %}
                 {%- for (x, y) in vk.fixed_comms %}
                 {%- let offset = vk.constants.len() %}
-                mstore({{ vk_mptr + offset + 2 * loop.index0 }}, {{ x|hex_padded(64) }}) // fixed_comms[{{ loop.index0 }}].x
-                mstore({{ vk_mptr + offset + 2 * loop.index0 + 1 }}, {{ y|hex_padded(64) }}) // fixed_comms[{{ loop.index0 }}].y
+                mstore({{ vk_mptr + offset + 2 * loop.index0 }}, {{ self::index_coord("fixed_comms", loop.index0, "x")|left_pad(24) }}) // fixed_comms[{{ loop.index0 }}].x
+                mstore({{ vk_mptr + offset + 2 * loop.index0 + 1 }}, {{ self::index_coord("fixed_comms", loop.index0, "y")|left_pad(24) }}) // fixed_comms[{{ loop.index0 }}].y
                 {%- endfor %}
                 {%- for (x, y) in vk.permutation_comms %}
                 {%- let offset = vk.constants.len() + 2 * vk.fixed_comms.len() %}
-                mstore({{ vk_mptr + offset + 2 * loop.index0 }}, {{ x|hex_padded(64) }}) // permutation_comms[{{ loop.index0 }}].x
-                mstore({{ vk_mptr + offset + 2 * loop.index0 + 1 }}, {{ y|hex_padded(64) }}) // permutation_comms[{{ loop.index0 }}].y
+                mstore({{ vk_mptr + offset + 2 * loop.index0 }}, {{ self::index_coord("permutation_comms", loop.index0, "x")|left_pad(24) }}) // permutation_comms[{{ loop.index0 }}].x
+                mstore({{ vk_mptr + offset + 2 * loop.index0 + 1 }}, {{ self::index_coord("permutation_comms", loop.index0, "y")|left_pad(24) }}) // permutation_comms[{{ loop.index0 }}].y
                 {%- endfor %}
                 {%- when None %}
                 // Copy vk into memory


### PR DESCRIPTION
I've been following summa-dev/summa-solvency#299 and figured a good approach would be to first make the verifying key accessible. I modified the contract template to support a new method `getVerifyingKey` (which can optionally take a contract address in the decoupled contracts architecture). 

After this I envision a simple cli tool (probably JS or wasm for browser compatibility) that calculates the digest using https://github.com/summa-dev/halo2-solidity-verifier/blob/d33972567f83f3218257b286b541ad97ba32928c/src/codegen.rs#L324

### Summary of changes:
* Re-factoring verifying key into constants in the Halo2Verifier
* Added getVerifyingKey() method, which returns vkey parameters
* Added auxiliary askama formatting methods